### PR TITLE
UF-7272 - Add municipality id to API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,16 +23,6 @@
 		<geojson-jackson.version>1.14</geojson-jackson.version>
 	</properties>
 	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<scope>runtime</scope>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>se.sundsvall.dept44</groupId>
-			<artifactId>dept44-common-validators</artifactId>
-		</dependency>
 		<!-- Test -->
 		<dependency>
 			<groupId>se.sundsvall.dept44</groupId>
@@ -44,6 +34,13 @@
 			<artifactId>mariadb</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- Framework -->
+		<dependency>
+			<groupId>se.sundsvall.dept44</groupId>
+			<artifactId>dept44-common-validators</artifactId>
+		</dependency>
+
 		<!-- Database-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -62,7 +59,14 @@
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-mysql</artifactId>
 		</dependency>
+
 		<!-- Other-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/src/integration-test/java/se/sundsvall/contract/apptest/ContractIT.java
+++ b/src/integration-test/java/se/sundsvall/contract/apptest/ContractIT.java
@@ -5,7 +5,6 @@ import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.PATCH;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.MediaType.ALL_VALUE;
 import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
@@ -32,38 +31,32 @@ class ContractIT extends AbstractAppTest {
 
 	@Test
 	void test01_readContract() throws Exception {
-
 		setupCall()
-			.withServicePath("/contracts/1")
+			.withServicePath("/contracts/1984/1")
 			.withHttpMethod(GET)
 			.withExpectedResponseStatus(OK)
 			.withExpectedResponseHeader(CONTENT_TYPE, List.of(APPLICATION_JSON_VALUE))
 			.withExpectedResponse(RESPONSE_FILE)
 			.sendRequestAndVerifyResponse()
 			.andReturnBody(Contract.class);
-
 	}
 
 	@Test
 	void test02_readContracts() throws Exception {
-
 		setupCall()
-			.withServicePath("/contracts")
+			.withServicePath("/contracts/1984")
 			.withHttpMethod(GET)
 			.withExpectedResponseStatus(OK)
 			.withExpectedResponseHeader(CONTENT_TYPE, List.of(APPLICATION_JSON_VALUE))
 			.withExpectedResponse(RESPONSE_FILE)
 			.sendRequestAndVerifyResponse()
-			.andReturnBody(new TypeReference<List<Contract>>() {
-
-			});
+			.andReturnBody(new TypeReference<List<Contract>>() {});
 	}
 
 	@Test
 	void test03_createContract() {
-
 		setupCall()
-			.withServicePath("/contracts")
+			.withServicePath("/contracts/1984")
 			.withHttpMethod(POST)
 			.withRequest("request.json")
 			.withExpectedResponseStatus(CREATED)
@@ -73,16 +66,13 @@ class ContractIT extends AbstractAppTest {
 
 	@Test
 	void test04_updateContract() {
-
 		setupCall()
-			.withServicePath("/contracts/1")
+			.withServicePath("/contracts/1984/1")
 			.withHttpMethod(PATCH)
 			.withHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
 			.withRequest("request.json")
-			.withExpectedResponseStatus(NO_CONTENT)
-			.withExpectedResponseHeader(CONTENT_TYPE, List.of(ALL_VALUE))
+			.withExpectedResponseStatus(OK)
+			.withExpectedResponseHeader(CONTENT_TYPE, List.of(APPLICATION_JSON_VALUE))
 			.sendRequestAndVerifyResponse();
-
 	}
-
 }

--- a/src/main/java/se/sundsvall/contract/api/ContractResource.java
+++ b/src/main/java/se/sundsvall/contract/api/ContractResource.java
@@ -71,7 +71,7 @@ class ContractResource {
 		responses = {
 			@ApiResponse(
 				responseCode = "201",
-				description = "No content",
+				description = "Successful operation",
 				headers = @Header(
 					name = LOCATION,
 					description = "Location of the created resource.",

--- a/src/main/java/se/sundsvall/contract/service/ContractService.java
+++ b/src/main/java/se/sundsvall/contract/service/ContractService.java
@@ -21,25 +21,23 @@ public class ContractService {
 		this.contractRepository = contractRepository;
 	}
 
-	public Long createContract(final Contract contract) {
-
+	public Long createContract(final String municipalityId, final Contract contract) {
 		return contractRepository.save(toEntity(contract)).getId();
 	}
 
-	public Contract getContract(final Long id) {
+	public Contract getContract(final String municipalityId, final Long id) {
 		return contractRepository.findById(id).map(ContractMapper::toDto).orElseThrow();
 	}
 
-	public List<Contract> getContracts(final ContractRequest request) {
-
+	public List<Contract> getContracts(final String municipalityId, final ContractRequest request) {
 		return contractRepository.findAll(createContractSpecification(request)).stream()
 			.map(ContractMapper::toDto)
 			.toList();
 	}
 
-	public void updateContract(final Long id, final Contract contract) {
+	public Contract updateContract(final String municipalityId, final Long id, final Contract contract) {
 		final var result = contractRepository.findById(id).orElseThrow();
 		final var updatedEntity = updateEntity(result, contract);
-		contractRepository.save(updatedEntity);
+		return ContractMapper.toDto(contractRepository.save(updatedEntity));
 	}
 }

--- a/src/test/java/se/sundsvall/contract/api/ContractResourceTest.java
+++ b/src/test/java/se/sundsvall/contract/api/ContractResourceTest.java
@@ -3,6 +3,7 @@ package se.sundsvall.contract.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -39,11 +40,10 @@ class ContractResourceTest {
 
 	@Test
 	void getContractsById() {
-
-		when(contractServiceMock.getContract(1L)).thenReturn(LandLeaseContract.builder().build());
+		when(contractServiceMock.getContract("1984", 1L)).thenReturn(LandLeaseContract.builder().build());
 
 		final var response = webTestClient.get()
-			.uri("/contracts/1")
+			.uri("/contracts/1984/1")
 			.exchange()
 			.expectStatus().isOk()
 			.expectHeader().contentType(APPLICATION_JSON)
@@ -52,14 +52,14 @@ class ContractResourceTest {
 			.getResponseBody();
 
 		assertThat(response).isNotNull();
-		verify(contractServiceMock, times(1)).getContract(any(Long.class));
+		verify(contractServiceMock, times(1)).getContract("1984", 1L);
 		verifyNoMoreInteractions(contractServiceMock);
 	}
 
 	@Test
 	void getContracts() {
 		webTestClient.get()
-			.uri(uriBuilder -> uriBuilder.path("/contracts")
+			.uri(uriBuilder -> uriBuilder.path("/contracts/1984")
 				.queryParam("personId", "1")
 				.build())
 			.exchange()
@@ -71,14 +71,12 @@ class ContractResourceTest {
 			.returnResult()
 			.getResponseBody();
 
-		verify(contractServiceMock, times(1)).getContracts(any(ContractRequest.class));
+		verify(contractServiceMock, times(1)).getContracts(eq("1984"), any(ContractRequest.class));
 		verifyNoMoreInteractions(contractServiceMock);
 	}
 
-
 	@Test
 	void postContracts() {
-
 		final var contract = LandLeaseContract.builder()
 			.withVersion(0)
 			.withArea(0)
@@ -86,32 +84,29 @@ class ContractResourceTest {
 			.build();
 
 		webTestClient.post()
-			.uri("/contracts")
+			.uri("/contracts/1984")
 			.bodyValue(contract)
 			.exchange()
 			.expectStatus().isCreated()
 			.expectHeader().contentType(ALL_VALUE)
 			.expectBody().isEmpty();
 
-		verify(contractServiceMock, times(1)).createContract(contract);
+		verify(contractServiceMock, times(1)).createContract("1984", contract);
 		verifyNoMoreInteractions(contractServiceMock);
 	}
 
 	@Test
 	void patchContracts() {
-
 		final var contract = TestFactory.getUpdatedLandLeaseContract();
 
 		webTestClient.patch()
-			.uri("/contracts/1")
+			.uri("/contracts/1984/1")
 			.bodyValue(contract)
 			.exchange()
-			.expectStatus().isNoContent()
-			.expectHeader().contentType(ALL_VALUE)
+			.expectStatus().isOk()
 			.expectBody().isEmpty();
 
-		verify(contractServiceMock, times(1)).updateContract(any(Long.class), any());
+		verify(contractServiceMock, times(1)).updateContract(eq("1984"), eq(1L), any());
 		verifyNoMoreInteractions(contractServiceMock);
 	}
-
 }


### PR DESCRIPTION
Adds `municipalityId` as a path parameter to all API endpoints. Also changes the HTTP status code for creating contracts from `204 NO CONTENT` to `201 CREATED` and modifies the endpoint for updating/patching a contract to return a `200 OK` with the updated contract as the body instead of `204 NO CONTENT`.